### PR TITLE
add date generator

### DIFF
--- a/rospbt/ros1/generators/builtin_msg_field_types.py
+++ b/rospbt/ros1/generators/builtin_msg_field_types.py
@@ -15,7 +15,8 @@ message field types which are usable in both, ROS1 and ROS2
 
 """
 
-from hypothesis.strategies import booleans, floats, integers
+import datetime
+from hypothesis.strategies import booleans, datetimes, floats, integers
 
 INT8_MIN_VALUE = -128
 """int: Minimal Int8 value (−1 × 2^7)."""
@@ -67,6 +68,10 @@ FLOAT64_MIN_VALUE = -1.7E+308
 FLOAT64_MAX_VALUE = +1.7E+308
 """float: Maximal Float32 value (+1.7E+308)."""
 
+DATE_MIN_VALUE = datetime.datetime(datetime.MINYEAR, 1, 1, 0, 0)
+"""date: Minimal ISO8601 Date value (0001-01-01 00:00:00)."""
+DATE_MAX_VALUE = datetime.datetime(datetime.MAXYEAR, 12, 31, 23, 59)
+"""date: Maximal ISO8601 Date value (9999-12-31 23:59:00)."""
 
 def bool():
     """
@@ -285,3 +290,25 @@ def float64(min_value=FLOAT64_MIN_VALUE, max_value=FLOAT64_MAX_VALUE, allow_nan=
         Strategy with preconfigured default values.
     """
     return floats(min_value, max_value, allow_nan, allow_infinity)
+
+
+def date(min_value=DATE_MIN_VALUE, max_value=DATE_MAX_VALUE):
+    """
+    Generates and shrinks values for ROS builtin message type "date".
+
+    TODO: Map Hypothesis values to YAML [.inf, -.Inf, .NAN].
+          http://www.yaml.org/refcard.html
+
+    Parameters
+    ----------
+    min_value : datetime.datetime
+        Minimal value to generate.
+    max_value : datetime.datetime
+        Maximal value to generate.
+
+    Returns
+    -------
+    hypothesis.strategies.datetimes()
+        Strategy with values taken from datetime library.
+    """
+    return datetimes(min_value, max_value)

--- a/rospbt/ros1/generators/builtin_msg_field_types.py
+++ b/rospbt/ros1/generators/builtin_msg_field_types.py
@@ -296,9 +296,6 @@ def date(min_value=DATE_MIN_VALUE, max_value=DATE_MAX_VALUE):
     """
     Generates and shrinks values for ROS builtin message type "date".
 
-    TODO: Map Hypothesis values to YAML [.inf, -.Inf, .NAN].
-          http://www.yaml.org/refcard.html
-
     Parameters
     ----------
     min_value : datetime.datetime

--- a/tests/builtin_msg_field_types_generators.py
+++ b/tests/builtin_msg_field_types_generators.py
@@ -78,7 +78,7 @@ def test_float64_generates_expected_min_value_as_default(generated_value):
     assert generated_value <= builtin_msg_field_types.FLOAT64_MAX_VALUE
 
 @given(builtin_msg_field_types.date())
-def test_date_generates_expected_min_value_as_default(generated_value):
+def test_date_generates_in_range_value_per_default(generated_value):
     """Verify default min. generated value for Date."""
     assert generated_value >= builtin_msg_field_types.DATE_MIN_VALUE
     assert generated_value <= builtin_msg_field_types.DATE_MAX_VALUE

--- a/tests/builtin_msg_field_types_generators.py
+++ b/tests/builtin_msg_field_types_generators.py
@@ -3,6 +3,7 @@
 Unit tests for the generators of the built-in message field datatypes.
 """
 
+import datetime
 from hypothesis import given
 from rospbt.ros1.generators import builtin_msg_field_types
 
@@ -75,3 +76,9 @@ def test_float64_generates_expected_min_value_as_default(generated_value):
     """Verify default min. generated value for Float64."""
     assert generated_value >= builtin_msg_field_types.FLOAT64_MIN_VALUE
     assert generated_value <= builtin_msg_field_types.FLOAT64_MAX_VALUE
+
+@given(builtin_msg_field_types.date())
+def test_date_generates_expected_min_value_as_default(generated_value):
+    """Verify default min. generated value for Date."""
+    assert generated_value >= builtin_msg_field_types.DATE_MIN_VALUE
+    assert generated_value <= builtin_msg_field_types.DATE_MAX_VALUE


### PR DESCRIPTION
I added the date generator following the ISO 8601 mentioned in the [ROS Parameter types](http://wiki.ros.org/Parameter%20Server#Parameter_Types).

The datetimes also has as a parameter timezone but I didn't add it. I think it is not needed since all dates are [accepted too](https://www.wikiwand.com/en/ISO_8601#/Time_zone_designators)

I ran all the `tox -e` commands. Some errors are there, but not linked to my contribution. Tests are passed successfully.

EDIT:
resolves #21